### PR TITLE
Use ParseIntPipe for route parameters

### DIFF
--- a/apps/api/src/assignments/assignments.controller.ts
+++ b/apps/api/src/assignments/assignments.controller.ts
@@ -6,6 +6,7 @@ import {
   Patch,
   Param,
   ValidationPipe,
+  ParseIntPipe,
 } from "@nestjs/common";
 import { AssignmentsService } from "./assignments.service";
 import { CreateAssignmentDto } from "./dto/create-assignment.dto";
@@ -27,21 +28,21 @@ export class AssignmentsController {
 
   @Get(":driverId/:loadId")
   findOne(
-    @Param("driverId") driverId: string,
-    @Param("loadId") loadId: string,
+    @Param("driverId", ParseIntPipe) driverId: number,
+    @Param("loadId", ParseIntPipe) loadId: number,
   ) {
-    return this.assignmentsService.findOne(+driverId, +loadId);
+    return this.assignmentsService.findOne(driverId, loadId);
   }
 
   @Patch(":driverId/:loadId")
   update(
-    @Param("driverId") driverId: string,
-    @Param("loadId") loadId: string,
+    @Param("driverId", ParseIntPipe) driverId: number,
+    @Param("loadId", ParseIntPipe) loadId: number,
     @Body(ValidationPipe) updateAssignmentDto: UpdateAssignmentDto,
   ) {
     return this.assignmentsService.update(
-      +driverId,
-      +loadId,
+      driverId,
+      loadId,
       updateAssignmentDto,
     );
   }

--- a/apps/api/src/drivers/drivers.controller.ts
+++ b/apps/api/src/drivers/drivers.controller.ts
@@ -7,6 +7,7 @@ import {
   Delete,
   ValidationPipe,
   Patch,
+  ParseIntPipe,
 } from "@nestjs/common";
 import { DriversService } from "./drivers.service";
 import { CreateDriverDto } from "./dto/create-driver.dto";
@@ -27,20 +28,20 @@ export class DriversController {
   }
 
   @Get(":id")
-  findOne(@Param("id") id: string) {
-    return this.driversService.findOne(+id);
+  findOne(@Param("id", ParseIntPipe) id: number) {
+    return this.driversService.findOne(id);
   }
 
   @Patch(":id")
   update(
-    @Param("id") id: string,
+    @Param("id", ParseIntPipe) id: number,
     @Body(ValidationPipe) updateDriverDto: UpdateDriverDto,
   ) {
-    return this.driversService.update(+id, updateDriverDto);
+    return this.driversService.update(id, updateDriverDto);
   }
 
   @Delete(":id")
-  remove(@Param("id") id: string) {
-    return this.driversService.remove(+id);
+  remove(@Param("id", ParseIntPipe) id: number) {
+    return this.driversService.remove(id);
   }
 }

--- a/apps/api/src/loads/loads.controller.ts
+++ b/apps/api/src/loads/loads.controller.ts
@@ -7,6 +7,7 @@ import {
   Delete,
   ValidationPipe,
   Patch,
+  ParseIntPipe,
 } from "@nestjs/common";
 import { LoadsService } from "./loads.service";
 import { CreateLoadDto } from "./dto/create-load.dto";
@@ -27,20 +28,20 @@ export class LoadsController {
   }
 
   @Get(":id")
-  findOne(@Param("id") id: string) {
-    return this.loadsService.findOne(+id);
+  findOne(@Param("id", ParseIntPipe) id: number) {
+    return this.loadsService.findOne(id);
   }
 
   @Patch(":id")
   update(
-    @Param("id") id: string,
+    @Param("id", ParseIntPipe) id: number,
     @Body(ValidationPipe) updateLoadDto: UpdateLoadDto,
   ) {
-    return this.loadsService.update(+id, updateLoadDto);
+    return this.loadsService.update(id, updateLoadDto);
   }
 
   @Delete(":id")
-  remove(@Param("id") id: string) {
-    return this.loadsService.remove(+id);
+  remove(@Param("id", ParseIntPipe) id: number) {
+    return this.loadsService.remove(id);
   }
 }

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -7,6 +7,7 @@ import {
   Delete,
   ValidationPipe,
   Patch,
+  ParseIntPipe,
 } from "@nestjs/common";
 import { UsersService } from "./users.service";
 import { CreateUserDto } from "./dto/create-user.dto";
@@ -27,20 +28,20 @@ export class UsersController {
   }
 
   @Get(":id")
-  findOne(@Param("id") id: string) {
-    return this.usersService.findOne(+id);
+  findOne(@Param("id", ParseIntPipe) id: number) {
+    return this.usersService.findOne(id);
   }
 
   @Patch(":id")
   update(
-    @Param("id") id: string,
+    @Param("id", ParseIntPipe) id: number,
     @Body(ValidationPipe) updateUserDto: UpdateUserDto,
   ) {
-    return this.usersService.update(+id, updateUserDto);
+    return this.usersService.update(id, updateUserDto);
   }
 
   @Delete(":id")
-  remove(@Param("id") id: string) {
-    return this.usersService.remove(+id);
+  remove(@Param("id", ParseIntPipe) id: number) {
+    return this.usersService.remove(id);
   }
 }


### PR DESCRIPTION
## Summary
- parse controller route params with Nest's `ParseIntPipe`
- drop manual number casts in controllers

## Testing
- ❌ `npm test --prefix apps/api` (fails: Cannot find module 'libs/security/password.service')
- ✅ `npm run lint --prefix apps/api`


------
https://chatgpt.com/codex/tasks/task_e_68c80d5dcbb4832886028bf4b7fb7530