### PR TITLE
feat(auth): add signup dto and update service

### DIFF
--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -10,6 +10,7 @@ import {
 import { AuthService } from "./auth.service";
 import { LoginDto } from "./dto/login.dto";
 import { AuthDto } from "./dto/auth.dto";
+import { SignUpDto } from "./dto/signup.dto";
 import { Public } from "./public.decorator";
 
 @Controller("auth")
@@ -18,15 +19,8 @@ export class AuthController {
 
   @Public()
   @Post("signup")
-  signup(
-    @Body(ValidationPipe)
-    data: {
-      email: string;
-      password: string;
-      name: string;
-    },
-  ) {
-    return this.authService.signup(data.email, data.password, data.name);
+  signup(@Body() data: SignUpDto) {
+    return this.authService.signup(data);
   }
 
   @HttpCode(200)

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -10,6 +10,7 @@ import { CreateUserDto } from "src/users/dto/create-user.dto";
 import { QueryFailedError } from "typeorm";
 import { randomUUID } from "crypto";
 import { PasswordService } from "libs/security/password.service";
+import { SignUpDto } from "./dto/signup.dto";
 
 @Injectable()
 export class AuthService {
@@ -19,11 +20,11 @@ export class AuthService {
     private password: PasswordService,
   ) {}
 
-  async signup(email: string, password: string, name: string): Promise<any> {
+  async signup(data: SignUpDto): Promise<any> {
     const user = new CreateUserDto();
-    user.email = email;
-    user.password = await this.password.hash(password);
-    user.name = name;
+    user.email = data.email;
+    user.password = await this.password.hash(data.password);
+    user.name = data.name;
     try {
       await this.usersService.create(user);
       return { message: "signup_success" };

--- a/apps/api/src/auth/dto/signup.dto.ts
+++ b/apps/api/src/auth/dto/signup.dto.ts
@@ -1,0 +1,13 @@
+import { IsEmail, IsString, MinLength } from "class-validator";
+
+export class SignUpDto {
+  @IsEmail()
+  email: string;
+
+  @IsString()
+  @MinLength(6)
+  password: string;
+
+  @IsString()
+  name: string;
+}


### PR DESCRIPTION
## Summary
- add SignUpDto with email, password, and name validators
- wire up signup flow in controller and service to use SignUpDto

## Testing
- `npm test` *(fails: Nest can't resolve dependencies in multiple specs)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c80d8d6e74832883f390dd1398e64f