### PR TITLE
Add targeted unit tests for assignments, loads, and publisher services

### DIFF
--- a/apps/api/src/assignments/assignments.service.spec.ts
+++ b/apps/api/src/assignments/assignments.service.spec.ts
@@ -1,12 +1,58 @@
+import { ConflictException } from "@nestjs/common";
 import { Test, TestingModule } from "@nestjs/testing";
+import { getRepositoryToken } from "@nestjs/typeorm";
+import { QueryFailedError } from "typeorm";
+import { Assignment } from "./entities/assignment.entity";
 import { AssignmentsService } from "./assignments.service";
+
+jest.mock(
+  "src/pubsub/publisher.service",
+  () => ({
+    PublisherService: class PublisherService {},
+  }),
+  { virtual: true },
+);
+
+jest.mock(
+  "src/audit/audit.service",
+  () => ({
+    AuditService: class AuditService {},
+  }),
+  { virtual: true },
+);
+
+const PublisherServiceToken = jest.requireMock("src/pubsub/publisher.service")
+  .PublisherService as new (...args: unknown[]) => unknown;
+const AuditServiceToken = jest.requireMock("src/audit/audit.service")
+  .AuditService as new (...args: unknown[]) => unknown;
 
 describe("AssignmentsService", () => {
   let service: AssignmentsService;
+  let repository: {
+    create: jest.Mock;
+    save: jest.Mock;
+  };
+  let publisher: { publishLoadAssigned: jest.Mock };
+  let audit: { record: jest.Mock };
 
   beforeEach(async () => {
+    repository = {
+      create: jest.fn((dto) => ({ ...dto })),
+      save: jest.fn(),
+    };
+    publisher = { publishLoadAssigned: jest.fn() };
+    audit = { record: jest.fn() };
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AssignmentsService],
+      providers: [
+        AssignmentsService,
+        {
+          provide: getRepositoryToken(Assignment),
+          useValue: repository,
+        },
+        { provide: PublisherServiceToken, useValue: publisher },
+        { provide: AuditServiceToken, useValue: audit },
+      ],
     }).compile();
 
     service = module.get<AssignmentsService>(AssignmentsService);
@@ -14,5 +60,36 @@ describe("AssignmentsService", () => {
 
   it("should be defined", () => {
     expect(service).toBeDefined();
+  });
+
+  it("should throw a conflict when creating a second active assignment for the same driver", async () => {
+    const dto = { driverId: 42, loadId: 7 };
+    const savedAssignment = { id: 1, ...dto };
+    repository.save
+      .mockResolvedValueOnce(savedAssignment)
+      .mockRejectedValueOnce(
+        new QueryFailedError("INSERT", [], {
+          code: "23505",
+          constraint: "idx_unique_active_assignment_driver",
+        }),
+      );
+
+    await expect(service.create(dto)).resolves.toEqual(savedAssignment);
+    expect(publisher.publishLoadAssigned).toHaveBeenCalledWith({
+      driverId: dto.driverId,
+      loadId: dto.loadId,
+    });
+    expect(audit.record).toHaveBeenCalledWith({
+      type: "ASSIGNED",
+      payload: { driverId: dto.driverId, loadId: dto.loadId },
+    });
+
+    const secondAttempt = service.create(dto);
+    await expect(secondAttempt).rejects.toThrow(ConflictException);
+    await expect(secondAttempt).rejects.toThrow(
+      "driver_already_has_active_assignment",
+    );
+    expect(publisher.publishLoadAssigned).toHaveBeenCalledTimes(1);
+    expect(audit.record).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/loads/loads.service.spec.ts
+++ b/apps/api/src/loads/loads.service.spec.ts
@@ -1,12 +1,50 @@
+import { CACHE_MANAGER } from "@nestjs/cache-manager";
 import { Test, TestingModule } from "@nestjs/testing";
+import { getRepositoryToken } from "@nestjs/typeorm";
+import { Load } from "./entities/load.entity";
 import { LoadsService } from "./loads.service";
 
 describe("LoadsService", () => {
   let service: LoadsService;
+  let repository: {
+    create: jest.Mock;
+    save: jest.Mock;
+    find: jest.Mock;
+    update: jest.Mock;
+    softDelete: jest.Mock;
+  };
+  let cache: {
+    get: jest.Mock;
+    set: jest.Mock;
+    del: jest.Mock;
+  };
 
   beforeEach(async () => {
+    repository = {
+      create: jest.fn(),
+      save: jest.fn(),
+      find: jest.fn(),
+      update: jest.fn(),
+      softDelete: jest.fn(),
+    };
+    cache = {
+      get: jest.fn(),
+      set: jest.fn(),
+      del: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [LoadsService],
+      providers: [
+        LoadsService,
+        {
+          provide: getRepositoryToken(Load),
+          useValue: repository,
+        },
+        {
+          provide: CACHE_MANAGER,
+          useValue: cache,
+        },
+      ],
     }).compile();
 
     service = module.get<LoadsService>(LoadsService);
@@ -14,5 +52,43 @@ describe("LoadsService", () => {
 
   it("should be defined", () => {
     expect(service).toBeDefined();
+  });
+
+  it("should fetch from the repository and cache results on cache miss", async () => {
+    const loads = [{ id: 1 } as Load];
+    cache.get.mockResolvedValueOnce(undefined);
+    repository.find.mockResolvedValueOnce(loads);
+
+    const result = await service.findAll();
+
+    expect(cache.get).toHaveBeenCalledWith("loads:all");
+    expect(repository.find).toHaveBeenCalledTimes(1);
+    expect(cache.set).toHaveBeenCalledWith("loads:all", loads, 60);
+    expect(result).toEqual(loads);
+  });
+
+  it("should return cached loads on cache hit", async () => {
+    const cachedLoads = [{ id: 2 } as Load];
+    cache.get.mockResolvedValueOnce(cachedLoads);
+
+    const result = await service.findAll();
+
+    expect(result).toEqual(cachedLoads);
+    expect(repository.find).not.toHaveBeenCalled();
+    expect(cache.set).not.toHaveBeenCalled();
+  });
+
+  it("should invalidate cached loads when updating", async () => {
+    repository.update.mockResolvedValueOnce(undefined);
+    cache.del.mockResolvedValueOnce(undefined);
+    const updateDto = { status: "UPDATED" } as unknown as Parameters<
+      LoadsService["update"]
+    >[1];
+
+    const result = await service.update(5, updateDto);
+
+    expect(repository.update).toHaveBeenCalledWith(5, updateDto);
+    expect(cache.del).toHaveBeenCalledWith("loads:all");
+    expect(result).toEqual({ message: "updated_load_successfully" });
   });
 });

--- a/apps/api/src/pubsub/publisher.service.spec.ts
+++ b/apps/api/src/pubsub/publisher.service.spec.ts
@@ -1,0 +1,63 @@
+import { PublisherService } from "./publisher.service";
+
+type PubSubMocks = {
+  publishMessageMock: jest.Mock;
+  topicMock: jest.Mock;
+  PubSubMock: jest.Mock;
+};
+
+jest.mock("@google-cloud/pubsub", () => {
+  const publishMessageMock = jest.fn();
+  const topicMock = jest.fn(() => ({ publishMessage: publishMessageMock }));
+  const PubSubMock = jest.fn(() => ({ topic: topicMock }));
+  return {
+    PubSub: PubSubMock,
+    __mocks: { publishMessageMock, topicMock, PubSubMock },
+  };
+});
+
+const {
+  __mocks: { publishMessageMock, topicMock, PubSubMock },
+} = jest.requireMock("@google-cloud/pubsub") as {
+  __mocks: PubSubMocks;
+};
+
+describe("PublisherService", () => {
+  let service: PublisherService;
+
+  beforeEach(() => {
+    publishMessageMock.mockReset();
+    topicMock.mockClear();
+    PubSubMock.mockClear();
+    service = new PublisherService();
+  });
+
+  it("should publish messages with serialized payloads", async () => {
+    const payload = { foo: "bar" };
+    publishMessageMock.mockResolvedValueOnce("message-123");
+
+    const messageId = await service.publish("test-topic", payload);
+
+    expect(PubSubMock).toHaveBeenCalledWith({ projectId: "fake" });
+    expect(topicMock).toHaveBeenCalledWith("test-topic");
+    expect(publishMessageMock).toHaveBeenCalledTimes(1);
+    const [{ data }] = publishMessageMock.mock.calls[0];
+    expect(JSON.parse(data.toString("utf-8"))).toEqual(payload);
+    expect(messageId).toBe("message-123");
+  });
+
+  it("should publish load assigned events and allow consumers to parse them", async () => {
+    const consumer = jest.fn();
+    publishMessageMock.mockImplementationOnce(async ({ data }) => {
+      consumer(JSON.parse(data.toString("utf-8")));
+      return "message-456";
+    });
+
+    const payload = { driverId: 9, loadId: 4 };
+    const messageId = await service.publishLoadAssigned(payload);
+
+    expect(topicMock).toHaveBeenCalledWith("load.assigned");
+    expect(consumer).toHaveBeenCalledWith(payload);
+    expect(messageId).toBe("message-456");
+  });
+});


### PR DESCRIPTION
## Summary
- mock the assignments repository and collaborators to assert duplicate driver assignments raise a conflict
- cover loads caching behavior by mocking the cache for misses, hits, and update invalidation
- add a publisher service spec that stubs Pub/Sub to verify publish serialization and consumer parsing

## Testing
- npm test -- --runTestsByPath src/assignments/assignments.service.spec.ts
- npm test -- --runTestsByPath src/loads/loads.service.spec.ts
- npm test -- --runTestsByPath src/pubsub/publisher.service.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68c8669a2abc8328912c21fd8580daa7