### PR TITLE
docs: document additional environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,36 @@
 ### Example environment variables for docker-compose
 # Copy this file to .env and edit values as needed.
 
-# Postgres
+# Hostname for the Postgres database instance
 POSTGRES_HOST=localhost
+# Port exposed by the Postgres server
 POSTGRES_PORT=5432
+# Name of the Postgres database used by the API
 POSTGRES_DB=haulguard
+# Username for connecting to Postgres
 POSTGRES_USER=hg
+# Password for the Postgres user
 POSTGRES_PASSWORD=hg
 
-# JWT
+# Secret used to sign JWTs
 JWT_SECRET=changeme
 
-# Bcrypt
+# Number of bcrypt hashing rounds to perform
 BCRYPT_ROUNDS=10
+# Additional pepper value mixed into bcrypt hashing
 BCRYPT_PEPPER=pepper
+
+# Hostname for the Redis cache instance
+REDIS_HOST=localhost
+# Port exposed by the Redis server
+REDIS_PORT=6379
+
+# Connection string for the MongoDB instance
+MONGO_URI=mongodb://localhost:27017
+# Name of the MongoDB database used by the application
+MONGO_DB=haulguard
+
+# Google Cloud Pub/Sub project identifier
+PUBSUB_PROJECT_ID=haulguard-dev
+# Host and port for the Pub/Sub emulator (set when using emulator)
+PUBSUB_EMULATOR_HOST=localhost:8085


### PR DESCRIPTION
## Summary
- add Redis, MongoDB, and Pub/Sub environment variables to the example file
- document the purpose of each environment variable in `.env.example`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c866b573b48328bc66d160906f1fa3