### PR TITLE
Record audit event when updating assignment status

### DIFF
--- a/apps/api/src/assignments/assignments.service.ts
+++ b/apps/api/src/assignments/assignments.service.ts
@@ -92,6 +92,10 @@ export class AssignmentsService {
       { id },
       { status: updateAssignmentDto.status },
     );
+    await this.audit.record({
+      type: updateAssignmentDto.status,
+      payload: { assignmentId: id },
+    });
     return { affected: result.affected || 0 };
   }
 }


### PR DESCRIPTION
## Summary
- record an audit event whenever an assignment status changes
- include the assignment identifier in the audit payload

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c866e3f7248328a3fe592e990883de