### PR TITLE
Add pubsub worker script and documentation

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -61,6 +61,9 @@ $ npm run start:dev
 
 # production mode
 $ npm run start:prod
+
+# pub/sub worker
+$ npm run start:worker
 ```
 
 ### Notes on Redis cache
@@ -93,6 +96,15 @@ $ npm run test:cov
 - On assignment creation the API publishes `load.assigned` with `{ driverId, loadId }`.
 - The Google Pub/Sub Emulator is included in `docker-compose.yml`.
 - Configure `PUBSUB_PROJECT_ID` and `PUBSUB_EMULATOR_HOST` (see `.env.example`).
+
+### Pub/Sub worker
+
+Build the project and run the worker to process subscribed events:
+
+```bash
+$ npm run build
+$ npm run start:worker
+```
 
 ## Deployment
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,6 +12,7 @@
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
+    "start:worker": "node dist/pubsub/consumer",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
## Summary
- add a start:worker npm script that executes the compiled Pub/Sub consumer
- document how to run the worker alongside the existing app commands

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c866e8962c8328bf54667c6b79888d