### PR TITLE
feat: add load assignment pubsub consumer

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,6 +12,7 @@
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
+    "start:worker": "nest start --entryFile pubsub/consumer",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -5,4 +5,4 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   await app.listen(process.env.PORT ?? 3000);
 }
-bootstrap();
+void bootstrap();

--- a/apps/api/src/pubsub/consumer.module.ts
+++ b/apps/api/src/pubsub/consumer.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { AuditModule } from "../audit/audit.module";
+import { ConsumerService } from "./consumer.service";
+
+@Module({
+  imports: [AuditModule],
+  providers: [ConsumerService],
+})
+export class ConsumerModule {}

--- a/apps/api/src/pubsub/consumer.service.ts
+++ b/apps/api/src/pubsub/consumer.service.ts
@@ -1,0 +1,80 @@
+import {
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  OnModuleInit,
+} from "@nestjs/common";
+import { Message, PubSub, Subscription } from "@google-cloud/pubsub";
+import { AuditService } from "../audit/audit.service";
+
+@Injectable()
+export class ConsumerService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(ConsumerService.name);
+  private readonly projectId: string;
+  private readonly subscriptionName: string;
+  private readonly pubsub: PubSub;
+  private subscription?: Subscription;
+
+  constructor(private readonly auditService: AuditService) {
+    this.projectId = process.env.PUBSUB_PROJECT_ID ?? "fake";
+    this.subscriptionName =
+      process.env.LOAD_ASSIGNED_SUBSCRIPTION ?? "load.assigned";
+    this.pubsub = new PubSub({ projectId: this.projectId });
+  }
+
+  onModuleInit(): void {
+    this.subscription = this.pubsub.subscription(this.subscriptionName);
+    this.subscription.on("message", (message) => {
+      void this.handleMessage(message);
+    });
+    this.subscription.on("error", (error) => {
+      this.logger.error("Subscription error", error.stack ?? error.message);
+    });
+    this.logger.log(
+      `Listening for messages on subscription ${this.subscriptionName} (project: ${this.projectId})`,
+    );
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    if (this.subscription) {
+      await this.subscription.close();
+      this.subscription.removeAllListeners();
+    }
+  }
+
+  private async handleMessage(message: Message): Promise<void> {
+    try {
+      const payload = this.parsePayload(message);
+      await this.auditService.record({
+        type: "ASSIGNED",
+        payload,
+      });
+      this.logger.debug(
+        `Processed load.assigned message for driver ${payload.driverId} and load ${payload.loadId}`,
+      );
+    } catch (error) {
+      const err = error as Error;
+      this.logger.error(
+        "Failed to process load.assigned message",
+        err.stack ?? err.message,
+      );
+    } finally {
+      message.ack();
+    }
+  }
+
+  private parsePayload(message: Message): { driverId: number; loadId: number } {
+    const content = message.data.toString();
+    const payload = JSON.parse(content) as Partial<{
+      driverId: unknown;
+      loadId: unknown;
+    }>;
+    const { driverId, loadId } = payload;
+
+    if (typeof driverId !== "number" || typeof loadId !== "number") {
+      throw new Error("Invalid load.assigned message payload");
+    }
+
+    return { driverId, loadId };
+  }
+}

--- a/apps/api/src/pubsub/consumer.ts
+++ b/apps/api/src/pubsub/consumer.ts
@@ -1,0 +1,12 @@
+import { Logger } from "@nestjs/common";
+import { NestFactory } from "@nestjs/core";
+import { ConsumerModule } from "./consumer.module";
+
+async function bootstrap() {
+  const app = await NestFactory.createApplicationContext(ConsumerModule);
+  const logger = new Logger("ConsumerBootstrap");
+  app.enableShutdownHooks();
+  logger.log("Consumer application context initialized");
+}
+
+void bootstrap();


### PR DESCRIPTION
## Summary
- add a Pub/Sub consumer service and module that records ASSIGNED audit events from load.assigned messages
- bootstrap a worker entry point so the consumer can run independently of the HTTP app
- add a start:worker npm script and tidy the main bootstrap invocation for lint compliance

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c866844190832884be0f0bd055f435